### PR TITLE
feat(init-npm-package): add trusted publishing setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@
 [oxc npm]: https://www.npmjs.com/package/@mcous/oxc-config
 [oxc version]: https://img.shields.io/npm/v/@mcous/oxc-config?style=flat-square
 
+## Utilities
+
+| Utility                           | Description                                                             |
+| --------------------------------- | ----------------------------------------------------------------------- |
+| [`@mcous/init-npm-package`][init] | Publish an initially empty npm package and configure trusted publishing |
+
+[init]: ./packages/init-npm-package
+
 ## Actions
 
 | Action                    | Path                     | Description                                       |

--- a/packages/init-npm-package/README.md
+++ b/packages/init-npm-package/README.md
@@ -8,7 +8,7 @@ Publish an initial, empty version of an npm package and configure it for [truste
 
 ```shell
 npm login
-pnpx @mcous/init-npm-package --name <name> --access <access> --workflow <workflow> --repo <repo> --env <env>"
+pnpx @mcous/init-npm-package --name <name> --access <access> --workflow <workflow> --repo <repo> --env <env>
 ```
 
 ### Example

--- a/packages/init-npm-package/README.md
+++ b/packages/init-npm-package/README.md
@@ -1,0 +1,18 @@
+# @mcous/init-npm-package
+
+Publish an initial, empty version of an npm package and configure it for [trusted publishing][].
+
+[trusted publishing]: https://docs.npmjs.com/trusted-publishers/
+
+## Usage
+
+```shell
+npm login
+pnpx @mcous/init-npm-package --name <name> --access <access> --workflow <workflow> --repo <repo> --env <env>"
+```
+
+### Example
+
+```shell
+pnpx @mcous/init-npm-package --name @mcous/foobar --access public --workflow ci.yaml --repo mcous/foobar --env npm
+```

--- a/packages/init-npm-package/bin/init-npm-package
+++ b/packages/init-npm-package/bin/init-npm-package
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
-#
-set -euo pipefail
 
-usage() {
-  echo "Usage: $0 --name <name> --access <access> --workflow <workflow> --repo <repo> --env <env>"
-  exit 1
-}
+set -euo pipefail
 
 name=""
 access=""
@@ -13,17 +8,37 @@ workflow=""
 repo=""
 env=""
 
+usage() {
+  echo "Usage: $0 --name <name> --access <access> --workflow <workflow> --repo <repo> --env <env>"
+  exit 1
+}
+
+get_value() {
+  if [[ "$1" == *=* ]]; then echo "${1#*=}"; else echo "$2"; fi
+}
+
+require_value() {
+  local value
+  value=$(get_value "$1" "${2:-}")
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "Missing value for ${1%%=*}"
+    usage
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --name)     name="$2";     shift 2 ;;
-    --access)   access="$2";   shift 2 ;;
-    --workflow) workflow="$2"; shift 2 ;;
-    --repo)     repo="$2";     shift 2 ;;
-    --env)      env="$2";      shift 2 ;;
+    --name|--name=*)         require_value "$1" "${2:-}"; name=$(get_value "$1" "${2:-}") ;;
+    --access|--access=*)     require_value "$1" "${2:-}"; access=$(get_value "$1" "${2:-}") ;;
+    --workflow|--workflow=*) require_value "$1" "${2:-}"; workflow=$(get_value "$1" "${2:-}") ;;
+    --repo|--repo=*)         require_value "$1" "${2:-}"; repo=$(get_value "$1" "${2:-}") ;;
+    --env|--env=*)           require_value "$1" "${2:-}"; env=$(get_value "$1" "${2:-}") ;;
     *) echo "Unknown argument: $1"; usage ;;
   esac
+  if [[ "$1" == *=* ]]; then shift 1; else shift 2; fi
 done
 
+# Validate required args
 [[ -z "$name" ]]     && echo "Missing --name"     && usage
 [[ -z "$access" ]]   && echo "Missing --access"   && usage
 [[ -z "$workflow" ]] && echo "Missing --workflow" && usage
@@ -39,9 +54,10 @@ echo "Env:      $env"
 dir=$(mktemp -d)
 manifest="$dir/package.json"
 readme="$dir/README.md"
+echo "$manifest"
 
 trap 'rm -rf "$dir"' EXIT
-echo "{\"name\": \"$name\", \"version\": \"0.0.0\"}" > $manifest
-echo "# $name" > $readme
+node -e "console.log(JSON.stringify({name: process.argv[1], version: '0.0.0'}))" "$name" > "$manifest"
+echo "# $name" > "$readme"
 npm publish "$dir" --access="$access"
 npm trust github "$name" --file="$workflow" --repo="$repo" --env="$env"

--- a/packages/init-npm-package/bin/init-npm-package
+++ b/packages/init-npm-package/bin/init-npm-package
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --name <name> --access <access> --workflow <workflow> --repo <repo> --env <env>"
+  exit 1
+}
+
+name=""
+access=""
+workflow=""
+repo=""
+env=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)     name="$2";     shift 2 ;;
+    --access)   access="$2";   shift 2 ;;
+    --workflow) workflow="$2"; shift 2 ;;
+    --repo)     repo="$2";     shift 2 ;;
+    --env)      env="$2";      shift 2 ;;
+    *) echo "Unknown argument: $1"; usage ;;
+  esac
+done
+
+[[ -z "$name" ]]     && echo "Missing --name"     && usage
+[[ -z "$access" ]]   && echo "Missing --access"   && usage
+[[ -z "$workflow" ]] && echo "Missing --workflow" && usage
+[[ -z "$repo" ]]     && echo "Missing --repo"     && usage
+[[ -z "$env" ]]      && echo "Missing --env"      && usage
+
+echo "Name:     $name"
+echo "Access:   $access"
+echo "Workflow: $workflow"
+echo "Repo:     $repo"
+echo "Env:      $env"
+
+dir=$(mktemp -d)
+manifest="$dir/package.json"
+readme="$dir/README.md"
+
+trap 'rm -rf "$dir"' EXIT
+echo "{\"name\": \"$name\", \"version\": \"0.0.0\"}" > $manifest
+echo "# $name" > $readme
+npm publish "$dir" --access="$access"
+npm trust github "$name" --file="$workflow" --repo="$repo" --env="$env"

--- a/packages/init-npm-package/package.json
+++ b/packages/init-npm-package/package.json
@@ -2,8 +2,8 @@
   "name": "@mcous/init-npm-package",
   "version": "1.0.0",
   "description": "Publish an initial, empty version of an npm package prior to CI-driven trusted publishing.",
-  "bin": "bin/init-npm-package",
-  "author": "Michael Cousins <michael@cousins.io> (https://michael.cousins.io)",
   "license": "MIT",
+  "author": "Michael Cousins <michael@cousins.io> (https://michael.cousins.io)",
+  "bin": "bin/init-npm-package",
   "type": "module"
 }

--- a/packages/init-npm-package/package.json
+++ b/packages/init-npm-package/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mcous/init-npm-package",
+  "version": "1.0.0",
+  "description": "Publish an initial, empty version of an npm package prior to CI-driven trusted publishing.",
+  "bin": "bin/init-npm-package",
+  "author": "Michael Cousins <michael@cousins.io> (https://michael.cousins.io)",
+  "license": "MIT",
+  "type": "module"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,8 @@ importers:
         specifier: ^8.59.3
         version: 8.59.3(eslint@10.4.0)(typescript@6.0.3)
 
+  packages/init-npm-package: {}
+
   packages/oxc-config: {}
 
   packages/prettier-config: {}


### PR DESCRIPTION
Since npm's trusted publishing only works with packages that already exist in the registry, I wanted a tool to create that initial package and configure trusted publishing. Other tools in this space exist, but for maximum trustability, I wanted to fully control the tool I use to do this