### PR TITLE
fix(oxlint): disable pedantic `typescript/strict-void-return` rule

### DIFF
--- a/packages/oxc-config/package.json
+++ b/packages/oxc-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcous/oxc-config",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "My base oxlint and oxfmt configurations.",
   "homepage": "https://github.com/mcous/js/tree/main/packages/oxc-config#readme",
   "bugs": {

--- a/packages/oxc-config/src/lint.ts
+++ b/packages/oxc-config/src/lint.ts
@@ -56,6 +56,7 @@ export default defineConfig({
       'error',
       { allowNullableBoolean: true },
     ],
+    'typescript/strict-void-return': 'off', // impractical with arrow functions
     'unicorn/no-array-callback-reference': 'off', // false positives on named callbacks
     'unicorn/no-useless-undefined': 'off', // explicit undefined is often clearer
 


### PR DESCRIPTION
This rule is too chatty for my taste